### PR TITLE
MacOSX compatibility fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+epub2txt

--- a/epub2txt.c
+++ b/epub2txt.c
@@ -7,7 +7,6 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/klib_buffer.c
+++ b/klib_buffer.c
@@ -4,7 +4,6 @@ klib_buffer.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_error.c
+++ b/klib_error.c
@@ -5,7 +5,6 @@ klib_error.c
 ============================================================================*/
 
 #include <errno.h>
-#include <malloc.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/klib_getopt.c
+++ b/klib_getopt.c
@@ -4,7 +4,6 @@ klib_getopt.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_getoptspec.c
+++ b/klib_getoptspec.c
@@ -4,7 +4,6 @@ klib_getoptspec.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_list.c
+++ b/klib_list.c
@@ -4,7 +4,6 @@ klib_list.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_log.c
+++ b/klib_log.c
@@ -4,7 +4,6 @@ klib_log.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_object.c
+++ b/klib_object.c
@@ -4,7 +4,6 @@ klib_object.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_path.c
+++ b/klib_path.c
@@ -6,7 +6,6 @@ klib_path.c
 #ifdef WIN32
 #include <windows.h>
 #endif
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_string.c
+++ b/klib_string.c
@@ -4,7 +4,6 @@ klib_string.c
 (c)2000-2012 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_wstring.c
+++ b/klib_wstring.c
@@ -5,7 +5,6 @@ klib_wstring.c
 ============================================================================*/
 #undef __STRICT_ANSI__
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/klib_xml.c
+++ b/klib_xml.c
@@ -4,7 +4,6 @@ klib_xml.c
 (c)2000-2016 Kevin Boone
 ============================================================================*/
 
-#include <malloc.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>

--- a/main.c
+++ b/main.c
@@ -7,7 +7,6 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <errno.h>
 #include "klib_log.h"


### PR DESCRIPTION
I removed explicit malloc.h includes (malloc is included from stdlib.h by default)
MacOSX clang compiler has no explicit malloc.h include file.