### PR TITLE
Allow to install other directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APPNAME=epub2txt
+DESTDIR=
 BINDIR=/usr/bin
 
 MANDIR=/usr/share/man
@@ -30,8 +31,10 @@ clean:
 	rm -f *.o $(APPNAME) *stackdump
 
 install:
-	cp -p $(APPNAME) $(BINDIR)
-	cp -pr man1/* $(MANDIR)/man1/
+	mkdir -p $(DESTDIR)/$(BINDIR)
+	cp -p $(APPNAME) $(DESTDIR)/$(BINDIR)
+	mkdir -p $(DESTDIR)/$(MANDIR)/man1/
+	cp -pr man1/* $(DESTDIR)/$(MANDIR)/man1/
 
 srcdist: clean
 	(cd ..; tar cvfz /tmp/$(APPNAME)-$(VERSION).tar.gz $(APPNAME))


### PR DESCRIPTION
added an empty `DESTDIR` in `Makefile` so that user can install to a different location.