### PR TITLE
Fixed bug with UTF-8 sequences starting with C2 in wrap mode. [METR-21516]

### DIFF
--- a/epub2txt.c
+++ b/epub2txt.c
@@ -489,17 +489,11 @@ void epub2txt_flush_para (const klib_String *para, int width, BOOL notrim)
         char c = s[i];
 
         if (mode == MODE_START && (c == ' ' 
-             || (unsigned char) c == (unsigned char)0xC2))
+             || ((unsigned char) c == (unsigned char)0xC2) && i < l - 1 && (unsigned char)s[i + 1] == (unsigned char)0xA0))
           {
-          if (i < l - 1)
-            {
-            if ((unsigned char)s[i + 1] == (unsigned char)0xA0) 
-              {
-              i++;
-              }
-            }
+          i+=c!=' ';
           // Absorb leading spaces
-          }	
+          }
         
 /*
         if ((mode == MODE_START && (c == ' ' 
@@ -518,12 +512,10 @@ void epub2txt_flush_para (const klib_String *para, int width, BOOL notrim)
           klib_string_append_byte (word, c);
           mode = MODE_WORD;
           }
-        else if ((mode == MODE_SPACE && (c == ' '
-             || (unsigned char) c == (unsigned char)0xC2))
-             &&
-             ((unsigned char)s[i + 1] == (unsigned char)0xA0)) 
+        else if (mode == MODE_SPACE && (c == ' '
+             || ((unsigned char) c == (unsigned char)0xC2 && i < l - 1 && (unsigned char)s[i + 1] == (unsigned char)0xA0)))
           {
-          i++;
+          i+=c!=' ';
           }
 /*
         else if (mode == MODE_SPACE && (c == ' '


### PR DESCRIPTION
See https://github.com/kevinboone/epub2txt/pull/6

> > Hi Kevin.
> > 
> > In wrap mode and UTF-8 output converter spoils UTF-8 sequences starting with C2 - C2 is got skipped and remaining byte appears in output. This pull request fixes it. I don't understand your code style and I hope that is okay.
> > 
> > File to reproduce bug is attached (no special command line options are needed).
> > [G.epub.zip](https://github.com/kevinboone/epub2txt/files/1308036/G.epub.zip)
> > 
> > Kind regards,
> > Vladimir.
> 
> On the file attached in first message:
> <img width="540" alt="screen shot 2017-09-16 at 12 24 43" src="https://user-images.githubusercontent.com/2255111/30511080-323a6e1c-9ada-11e7-9a26-90e27c83d876.png">