### PR TITLE
Remove malloc.h references

### DIFF
--- a/epub2txt.c
+++ b/epub2txt.c
@@ -9,9 +9,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
 #include <errno.h>
 #include <ctype.h>
 #include "klib_log.h"

--- a/klib_buffer.c
+++ b/klib_buffer.c
@@ -8,9 +8,7 @@ klib_buffer.c
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/klib_error.c
+++ b/klib_error.c
@@ -7,9 +7,7 @@ klib_error.c
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <string.h>
 #include "klib_string.h"
 #include "klib_error.h"

--- a/klib_object.c
+++ b/klib_object.c
@@ -8,9 +8,7 @@ klib_object.c
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <wchar.h>
 #include <sys/types.h>

--- a/klib_string.c
+++ b/klib_string.c
@@ -9,9 +9,7 @@ klib_string.c
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <wchar.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/klib_xml.c
+++ b/klib_xml.c
@@ -9,9 +9,7 @@ klib_xml.c
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "klib_log.h"


### PR DESCRIPTION
This pull request removes `<malloc.h>` include directives. Where necessary, `<stdlib.h>` include directives are added instead.

I see that some `<malloc.h>` includes were restored in 96b82fb8, so please feel free to reject this pull request if there is a specific reason to keep the `<malloc.h>` includes. Was there any particular reason to reintroduce them after they had been removed?