### PR TITLE
Remove obsolete GNU style field designators

### DIFF
--- a/klib_buffer.c
+++ b/klib_buffer.c
@@ -24,9 +24,9 @@ void klib_buffer_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_buffer =
   {
-  obj_size: sizeof (klib_Buffer), 
-  init_fn: klib_buffer_init,
-  class_name: "klib_Buffer"
+  .obj_size = sizeof (klib_Buffer),
+  .init_fn = klib_buffer_init,
+  .class_name = "klib_Buffer"
   };
 
 typedef struct _klib_Buffer_priv

--- a/klib_error.c
+++ b/klib_error.c
@@ -20,9 +20,9 @@ void klib_error_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_error =
   {
-  obj_size: sizeof (klib_Error), 
-  init_fn: klib_error_init,
-  class_name: "klib_Error"
+  .obj_size = sizeof (klib_Error),
+  .init_fn = klib_error_init,
+  .class_name = "klib_Error"
   };
 
 typedef struct _klib_Error_priv

--- a/klib_getopt.c
+++ b/klib_getopt.c
@@ -29,9 +29,9 @@ void klib_getopt_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_getopt =
   {
-  obj_size: sizeof (klib_GetOpt), 
-  init_fn: klib_getopt_init,
-  class_name: "klib_GetOpt"
+  .obj_size = sizeof (klib_GetOpt),
+  .init_fn = klib_getopt_init,
+  .class_name = "klib_GetOpt"
   };
 
 typedef struct _klib_GetOpt_priv

--- a/klib_getoptspec.c
+++ b/klib_getoptspec.c
@@ -29,9 +29,9 @@ void klib_getoptspec_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_getoptspec =
   {
-  obj_size: sizeof (klib_GetOptSpec), 
-  init_fn: klib_getoptspec_init,
-  class_name: "klib_GetOptSpec"
+  .obj_size = sizeof (klib_GetOptSpec),
+  .init_fn = klib_getoptspec_init,
+  .class_name = "klib_GetOptSpec"
   };
 
 typedef struct _klib_GetOptSpec_priv

--- a/klib_list.c
+++ b/klib_list.c
@@ -28,9 +28,9 @@ void klib_list_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_list =
   {
-  obj_size: sizeof (klib_List), 
-  init_fn: klib_list_init,
-  class_name: "klib_List"
+  .obj_size = sizeof (klib_List),
+  .init_fn = klib_list_init,
+  .class_name = "klib_List"
   };
 
 typedef struct _klib_List_priv

--- a/klib_path.c
+++ b/klib_path.c
@@ -29,9 +29,9 @@ void klib_path_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_path =
   {
-  obj_size: sizeof (klib_Path), 
-  init_fn: klib_path_init,
-  class_name: "klib_Path"
+  .obj_size = sizeof (klib_Path),
+  .init_fn = klib_path_init,
+  .class_name = "klib_Path"
   };
 
 typedef struct _klib_Path_priv

--- a/klib_string.c
+++ b/klib_string.c
@@ -29,9 +29,9 @@ void klib_string_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_string =
   {
-  obj_size: sizeof (klib_String), 
-  init_fn: klib_string_init,
-  class_name: "klib_String"
+  .obj_size = sizeof (klib_String),
+  .init_fn = klib_string_init,
+  .class_name = "klib_String"
   };
 
 typedef struct _klib_String_priv

--- a/klib_wstring.c
+++ b/klib_wstring.c
@@ -31,9 +31,9 @@ void klib_wstring_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_wstring =
   {
-  obj_size: sizeof (klib_WString), 
-  init_fn: klib_wstring_init,
-  class_name: "klib_WString"
+  .obj_size = sizeof (klib_WString),
+  .init_fn = klib_wstring_init,
+  .class_name = "klib_WString"
   };
 
 typedef struct _klib_WString_priv

--- a/klib_xml.c
+++ b/klib_xml.c
@@ -27,9 +27,9 @@ void klib_xml_dispose (klib_Object *self);
 
 static klib_Spec klib_spec_xml =
   {
-  obj_size: sizeof (klib_Xml), 
-  init_fn: klib_xml_init,
-  class_name: "klib_Xml"
+  .obj_size = sizeof (klib_Xml),
+  .init_fn = klib_xml_init,
+  .class_name = "klib_Xml"
   };
 
 typedef struct _klib_Xml_priv


### PR DESCRIPTION
This pull request replaces old-style GNU field designators currently used in parts of epub2txt with their more modern C99-style counterparts.

According to [Using the GNU Compiler Collection (GCC): Designated Initializers](https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html), the old style has been "obsolete since GCC 2.5" and its usage results in compiler warnings on recent versions of clang.